### PR TITLE
fixup! Initiate the documents

### DIFF
--- a/publish/Makefile
+++ b/publish/Makefile
@@ -10,6 +10,4 @@ all: cloudy.tex ap.tex kubernetes.tex docker.tex References.bib
 	@pdflatex cloudy.tex
 
 clean:
-	@cd ap; make clean
-	@cd docker; make clean
-	@cd kubernetes; make clean
+	@rm *.aux *.blg *.bbl *.log *.pdf

--- a/publish/ap.tex
+++ b/publish/ap.tex
@@ -1,1 +1,2 @@
-\title{Access Point}
+\section{Access Point} \label{AP}
+Hello Access Point

--- a/publish/cloudy.tex
+++ b/publish/cloudy.tex
@@ -1,17 +1,27 @@
 % Need to define style
-\documentclass{article}
-\includeonly{ap/ap,docker/docker,kuberntes/kuberntes}
-\begin{document}
+\documentclass[11pt,a4paper]{article}
+\usepackage[utf8]{inputenc}
 \title{Cloud Study}
+\author{Cloud Computing Study Group}
+\date{\today}
+\includeonly{ap,docker,kubernetes,References}
+\begin{document}
+\begin{abstract}
+DevOps and MicoServices
+\end{abstract}
+\maketitle
 Hello cloud \cite{CloudStudy}
+
 \include{ap}
 \include{docker}
-\include{kuberntes}
+\include{kubernetes}
+
 %\begin{thebibliography}{999}
 %  \emph{Cloud} Study documentation using \LaTex,
 %  1st Edition,
 %  2019.
 %\end{thebibliography}
+
 \bibliography{References}
 \bibliographystyle{plain}
 \end{document}

--- a/publish/docker.tex
+++ b/publish/docker.tex
@@ -1,1 +1,3 @@
-\title{Docker}
+\section{Docker} \label{DOCKER}
+
+Hello Docker

--- a/publish/kubernetes.tex
+++ b/publish/kubernetes.tex
@@ -1,1 +1,3 @@
-\title{Kubernetes}
+\section{Kubernetes} \label{K8S}
+
+Hello Kubernetes


### PR DESCRIPTION
@comlhj1114 님 review 해주신거 반영한 fixup PR 입니다.
그런데..

Document class 도 article 로 되어 있는데,
\section 이 알 수 없는 명령이라는 에러가 계속 나네요.. +_+;;;;

```
This is pdfTeX, Version 3.14159265-2.6-1.40.18 (TeX Live 2017/Debian) (preloaded format=pdflatex)
 restricted \write18 enabled.
entering extended mode
(./ap.tex
LaTeX2e <2017-04-15>
Babel <3.18> and hyphenation patterns for 26 language(s) loaded.
! Undefined control sequence.
l.1 \section
            {Access Point} \label{AP}
?
! Emergency stop.
l.1 \section
            {Access Point} \label{AP}
!  ==> Fatal error occurred, no output PDF file produced!
Transcript written on ap.log.
Makefile:4: recipe for target 'all' failed
make: *** [all] Error 1
```
publish 폴더 밑에서 make 를 해보면 에러가 나는데요 (이 PR 을 받아서)
뭐가 문제일까요+_+